### PR TITLE
fix: Fixing new version dialog always popping up

### DIFF
--- a/src/TwitchStreamingTools/Views/MainWindow.axaml.cs
+++ b/src/TwitchStreamingTools/Views/MainWindow.axaml.cs
@@ -58,6 +58,11 @@ public partial class MainWindow : Window {
       }
 
       if (serverVersion.name?.Equals(localVersion, StringComparison.InvariantCultureIgnoreCase) ?? true) {
+// Had to add this because code clean up tools were removing the "redundant" return statement.
+// which was causing the check to always be ignored.
+#if !DEBUG
+        return;
+#endif
       }
 
 #if !DEBUG


### PR DESCRIPTION
This was due to the Rider code clean up tools removing the return. It was ultimately my fault for not adding the return back in when I was reviewing the files changes but realistically I'll keep making that manual mistake if the manual keeps existing. This should keep it in as the code will be ignored when the code clean up is run.

closes #23