### PR TITLE
chore: centralize version number

### DIFF
--- a/src/TwitchStreamingTools/Constants.cs
+++ b/src/TwitchStreamingTools/Constants.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 
 using Avalonia.Input.Platform;
 
@@ -39,6 +40,11 @@ public static class Constants {
   ///   The twitch app redirect link.
   /// </summary>
   public const string TWITCH_CLIENT_REDIRECT = $"{API_SITE_DOMAIN}/api/v1/user/twitch-login/twitch-streaming-tools";
+
+  /// <summary>
+  /// The version of the application being run right now.
+  /// </summary>
+  public static readonly string? APP_VERSION = Assembly.GetEntryAssembly()?.GetName().Version?.ToString()[..^2];
 
   /// <summary>
   ///   The reference to the clipboard API.

--- a/src/TwitchStreamingTools/ViewModels/Pages/AccountViewModel.cs
+++ b/src/TwitchStreamingTools/ViewModels/Pages/AccountViewModel.cs
@@ -83,7 +83,7 @@ public class AccountViewModel : PageViewModelBase, IDisposable {
   /// <summary>
   ///   The application version number.
   /// </summary>
-  public string? Version => Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+  public string? Version => Constants.APP_VERSION;
 
   /// <inheritdoc />
   public void Dispose() {

--- a/src/TwitchStreamingTools/Views/MainWindow.axaml.cs
+++ b/src/TwitchStreamingTools/Views/MainWindow.axaml.cs
@@ -57,7 +57,7 @@ public partial class MainWindow : Window {
     Task.Factory.StartNew(async () => {
       GithubLatestReleaseJson? serverVersion =
         await GitHubUpdateManager.GetLatestVersion("nullinside-development-group", "twitch-streaming-tools");
-      string? localVersion = Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+      string? localVersion = Constants.APP_VERSION;
       if (null == serverVersion || string.IsNullOrWhiteSpace(serverVersion.name) ||
           string.IsNullOrWhiteSpace(localVersion)) {
         return;


### PR DESCRIPTION
moving the version number to a constant file so I chop the last octet off in peace.