### PR TITLE
feat: Adding slider for playback speed based on tests

### DIFF
--- a/src/TwitchStreamingTools/ViewModels/Pages/ChatViewModel.cs
+++ b/src/TwitchStreamingTools/ViewModels/Pages/ChatViewModel.cs
@@ -169,7 +169,7 @@ public class ChatViewModel : PageViewModelBase, IDisposable {
         OutputDevice = Configuration.GetDefaultAudioDevice(),
         TtsOn = true,
         TtsVoice = Configuration.GetDefaultTtsVoice(),
-        TtsVolume = 100
+        TtsVolume = 50
       }).ToList();
 
     _configuration.WriteConfiguration();
@@ -194,7 +194,7 @@ public class ChatViewModel : PageViewModelBase, IDisposable {
         OutputDevice = Configuration.GetDefaultAudioDevice(),
         TtsOn = true,
         TtsVoice = Configuration.GetDefaultTtsVoice(),
-        TtsVolume = 100
+        TtsVolume = 50
       }).ToList();
 
     _configuration.WriteConfiguration();
@@ -267,6 +267,10 @@ public class ChatViewModel : PageViewModelBase, IDisposable {
   ///   Connects to the twitch chats in the configuration file.
   /// </summary>
   private void InitializeTwitchChatConnections() {
+    if (Design.IsDesignMode) {
+      return;
+    }
+
     foreach (TwitchChatConfiguration channel in _configuration.TwitchChats ?? []) {
       if (string.IsNullOrWhiteSpace(channel.TwitchChannel)) {
         continue;

--- a/src/TwitchStreamingTools/Views/Pages/SettingsView/SettingsView.axaml
+++ b/src/TwitchStreamingTools/Views/Pages/SettingsView/SettingsView.axaml
@@ -19,6 +19,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -74,17 +75,50 @@
                     IsSnapToTickEnabled="True"
                     Value="{Binding TtsVolume}" />
         </Grid>
-
-
         <Label Grid.Row="3"
+               Grid.Column="0"
+               HorizontalAlignment="Right"
+               VerticalAlignment="Top"
+               Margin="0 12 0 0">
+            TTS Playback Speed:
+        </Label>
+        <Grid Grid.Row="3"
+              Grid.Column="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0"
+                       VerticalAlignment="Center"
+                       HorizontalAlignment="Center"
+                       Text="{Binding #Speed.Value, StringFormat={}{0:F2}x}"
+                       Margin="0 0 10 0" />
+            <Slider Grid.Column="1"
+                    x:Name="Speed"
+                    TickFrequency="0.1"
+                    SmallChange="0.1"
+                    LargeChange="1.0"
+                    IsSnapToTickEnabled="True"
+                    Minimum="-0.5"
+                    Maximum="3"
+                    Value="{Binding Speed}" />
+        </Grid>
+        <Label Grid.Row="4"
                Grid.Column="0"
                HorizontalAlignment="Right"
                VerticalAlignment="Top"
                Margin="0 5 0 0">
             Advanced TTS Playback:
         </Label>
-        <Grid Grid.Row="3"
-              Grid.Column="1">
+        <Button Grid.Row="4"
+                Grid.Column="1"
+                IsVisible="{Binding !ShowAdvancedTts}"
+                Command="{Binding ToggleAdvancedTtsCommand}">
+            Show Options
+        </Button>
+        <Grid Grid.Row="4"
+              Grid.Column="1"
+              IsVisible="{Binding ShowAdvancedTts}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -150,25 +184,25 @@
                           IsChecked="{Binding TurnOnSpeech}" />
             </Grid>
         </Grid>
-        <Label Grid.Row="4"
+        <Label Grid.Row="5"
                Grid.Column="0"
                HorizontalAlignment="Right"
                VerticalAlignment="Top"
                Margin="0 5 0 0">
             Skip User TTS:
         </Label>
-        <Grid Grid.Row="4"
+        <Grid Grid.Row="5"
               Grid.Column="1">
             <settingsView:TtsSkipUsernamesControl Margin="0,0,5,0" DataContext="{Binding TtsSkipUsernamesViewModel}" />
         </Grid>
-        <Label Grid.Row="5"
+        <Label Grid.Row="6"
                Grid.Column="0"
                HorizontalAlignment="Right"
                VerticalAlignment="Top"
                Margin="0 5 0 0">
             Phonetic Spellings:
         </Label>
-        <Grid Grid.Row="5"
+        <Grid Grid.Row="6"
               Grid.Column="1">
             <settingsView:TtsPhoneticWordsControl Margin="0,0,5,0" DataContext="{Binding TtsPhoneticWordsViewModel}" />
         </Grid>


### PR DESCRIPTION
Tested some settings and examples and it looks like the tempo is the best way of fast forwarding. Following the rule that tempo +50 == 2x playback speed.

You can fast forward with rate but it makes you sound like the chipmunks. You can kind of fix it at lower rates by lowering the pitch but even at 2x speeds its an obvious distortion pitch aside.

You can also fast forward with beats per minute but it almost seems time dependant on the length of the TTS and I didn't want to research an equation. The effect on TTS, when set close to correctly, sounds no different to me than changing the tempo.

closes #69